### PR TITLE
exit without arguments should return 0

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -57,7 +57,7 @@ def main() -> None:
         )
         assert (
             proc.returncode == 0
-        ), f"expected exit to terminate with exit code 1, got: {proc.returncode}"
+        ), f"expected exit to terminate with exit code 0, got: {proc.returncode}"
         info("OK")
 
     with tempfile.TemporaryDirectory() as dir:


### PR DESCRIPTION
There is an error in the string printed by a test, @martin-fink confirmed it [here](https://ls1-courses-tum.slack.com/archives/C04JTLCK25Q/p1684585047636579?thread_ts=1684575839.945739&cid=C04JTLCK25Q)